### PR TITLE
Add vite 8.x to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "vite-plugin-dts": "^4.5.3"
   },
   "peerDependencies": {
-    "vite": ">= 6.0.0"
+    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
This marks vite 8.x (and 7.x) as potential peer dependencies.